### PR TITLE
fix: Refactor `LOAD:` message into hex values

### DIFF
--- a/notecard/package.go
+++ b/notecard/package.go
@@ -94,7 +94,7 @@ func dfuPackage(outfile string, hostProcessorType string, args []string) (err er
 	prefix += "HOST: " + hostProcessorType + "\n"
 	for i := range addresses {
 		cleanFn := strings.ReplaceAll(filenames[i], ",", "")
-		prefix += fmt.Sprintf("LOAD: %s,%d,%d,%d,%x\n", cleanFn, addresses[i], regions[i], len(files[i]), md5.Sum(files[i]))
+		prefix += fmt.Sprintf("LOAD: %s,0x%08x,0x%x,0x%x,%x\n", cleanFn, addresses[i], regions[i], len(files[i]), md5.Sum(files[i]))
 	}
 	prefix += "/// BINPACK ///\n"
 


### PR DESCRIPTION
```
/// BINPACK ///
WHEN: 2022-04-29 20:51:45 UTC
HOST: stm32
LOAD: BlinkDoubleExternal.ino.bin,134217728,33560,33560,6d6e817cc61723d0b9aef58d74fad6d4
LOAD: uint32_t_1024.bin,135266304,4,4,e95cecc0838acd2218f0e980331878c4
LOAD: uint32_t_1024.bin,135270400,4,4,e95cecc0838acd2218f0e980331878c4
/// BINPACK ///
```
Becomes
```
/// BINPACK ///
WHEN: 2022-04-29 21:04:23 UTC
HOST: stm32
LOAD: BlinkDoubleExternal.ino.bin,0x08000000,0x8318,0x8318,6d6e817cc61723d0b9aef58d74fad6d4
LOAD: uint32_t_1024.bin,0x08100000,0x4,0x4,e95cecc0838acd2218f0e980331878c4
LOAD: uint32_t_1024.bin,0x08101000,0x4,0x4,e95cecc0838acd2218f0e980331878c4
/// BINPACK ///
```