### PR TITLE
fix: Refactor `LOAD:` message into hex values

### DIFF
--- a/notecard/package.go
+++ b/notecard/package.go
@@ -92,10 +92,13 @@ func dfuPackage(outfile string, hostProcessorType string, args []string) (err er
 	prefix := "/// BINPACK ///\n"
 	prefix += "WHEN: " + now.Format("2006-01-02 15:04:05 UTC") + "\n"
 	prefix += "HOST: " + hostProcessorType + "\n"
+	hprefix := prefix
 	for i := range addresses {
 		cleanFn := strings.ReplaceAll(filenames[i], ",", "")
 		prefix += fmt.Sprintf("LOAD: %s,%d,%d,%d,%x\n", cleanFn, addresses[i], regions[i], len(files[i]), md5.Sum(files[i]))
+		hprefix += fmt.Sprintf("LOAD: %s,0x%08x,0x%x,0x%x,%x\n", cleanFn, addresses[i], regions[i], len(files[i]), md5.Sum(files[i]))
 	}
+	hprefix += "/// BINPACK ///\n"
 	prefix += "/// BINPACK ///\n"
 
 	// Create the output file
@@ -141,7 +144,7 @@ func dfuPackage(outfile string, hostProcessorType string, args []string) (err er
 	}
 
 	// Done
-	fmt.Printf("%s now incorporates %d files and is %d bytes:\n\n%s\n", outfile, len(addresses), fi.Size(), prefix)
+	fmt.Printf("%s now incorporates %d files and is %d bytes:\n\n%s\n", outfile, len(addresses), fi.Size(), hprefix)
 	return nil
 
 }


### PR DESCRIPTION
```
/// BINPACK ///
WHEN: 2022-04-29 20:51:45 UTC
HOST: stm32
LOAD: BlinkDoubleExternal.ino.bin,134217728,33560,33560,6d6e817cc61723d0b9aef58d74fad6d4
LOAD: uint32_t_1024.bin,135266304,4,4,e95cecc0838acd2218f0e980331878c4
LOAD: uint32_t_1024.bin,135270400,4,4,e95cecc0838acd2218f0e980331878c4
/// BINPACK ///
```

Becomes:

```
/// BINPACK ///
WHEN: 2022-04-29 21:04:23 UTC
HOST: stm32
LOAD: BlinkDoubleExternal.ino.bin,0x08000000,0x8318,0x8318,6d6e817cc61723d0b9aef58d74fad6d4
LOAD: uint32_t_1024.bin,0x08100000,0x4,0x4,e95cecc0838acd2218f0e980331878c4
LOAD: uint32_t_1024.bin,0x08101000,0x4,0x4,e95cecc0838acd2218f0e980331878c4
/// BINPACK ///
```