### PR TITLE
fix: change notecard -req not to do marshaling

### DIFF
--- a/notecard/scan.go
+++ b/notecard/scan.go
@@ -8,8 +8,8 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"os"
 	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 


### PR DESCRIPTION
I ran into an issue in which a field not present in the request structure was being dropped, due to the fact that the golang versions were different in the note-go libraries I was using.

This change will use the json structure directly on notecard -req.