### PR TITLE
Return on io error to prevent misleading error message

### DIFF
--- a/notecard/dfu.go
+++ b/notecard/dfu.go
@@ -26,6 +26,10 @@ func dfuSideload(filename string, verbose bool) (err error) {
 	binaryMax := 0
 	var rsp notecard.Request
 	rsp, err = card.TransactionRequest(notecard.Request{Req: "card.binary"})
+	if note.ErrorContains(err, note.ErrCardIo) {
+		return err
+	}
+
 	if err == nil {
 
 		// Get the maximum size that the notecard can handle


### PR DESCRIPTION
Previously an io error would result in the response: "notecard is running firmware that is too old to use sideload"