### PR TITLE
feat: add the ability to get and set env vars in a batch way across devices and fleets

### DIFF
--- a/notecard/explore.go
+++ b/notecard/explore.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Explore the contents of this device
-func explore(includeReserved bool) (err error) {
+func explore(includeReserved bool, pretty bool) (err error) {
 
 	// Get the list of notefiles
 	req := notecard.Request{Req: notecard.ReqFileChanges}
@@ -65,9 +65,15 @@ func explore(includeReserved bool) (err error) {
 			}
 			fmt.Printf("\n")
 			if n.Body != nil {
-				bodyJSON, err := note.JSONMarshal(*n.Body)
+				var bodyJSON []byte
+				prefix := "            "
+				if pretty {
+					bodyJSON, err = note.JSONMarshalIndent(*n.Body, prefix, "    ")
+				} else {
+					bodyJSON, err = note.JSONMarshal(*n.Body)
+				}
 				if err == nil {
-					fmt.Printf("            %s\n", string(bodyJSON))
+					fmt.Printf("%s%s\n", prefix, string(bodyJSON))
 				}
 			}
 			if n.Payload != nil {

--- a/notecard/main.go
+++ b/notecard/main.go
@@ -38,6 +38,8 @@ func main() {
 	go signalHandler()
 
 	// Process actions
+	var actionPretty bool
+	flag.BoolVar(&actionPretty, "pretty", false, "format JSON output indented")
 	var actionRequest string
 	flag.StringVar(&actionRequest, "req", "", "perform the specified request (in quotes)")
 	var actionWhenConnected bool
@@ -638,7 +640,11 @@ func main() {
 			// Output the response to the console
 			if !actionVerbose {
 				if err == nil {
-					rspJSON, _ = note.JSONMarshal(rsp)
+					if actionPretty {
+						rspJSON, _ = note.JSONMarshalIndent(rsp, "", "    ")
+					} else {
+						rspJSON, _ = note.JSONMarshal(rsp)
+					}
 					fmt.Printf("%s\n", rspJSON)
 				}
 			}
@@ -708,7 +714,7 @@ func main() {
 	}
 
 	if err == nil && actionExplore {
-		err = explore(actionReserved)
+		err = explore(actionReserved, actionPretty)
 	}
 
 	// Process errors

--- a/notehub/app.go
+++ b/notehub/app.go
@@ -1,0 +1,251 @@
+// Copyright 2024 Blues Inc.  All rights reserved.
+// Use of this source code is governed by licenses granted by the
+// copyright holder including that found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"sort"
+	"strings"
+
+	"github.com/blues/note-cli/lib"
+	notegoapi "github.com/blues/note-go/notehub/api"
+)
+
+type Metadata struct {
+	Name string `json:"name,omitempty"`
+	UID  string `json:"uid,omitempty"`
+	BA   string `json:"billing_account_uid,omitempty"`
+}
+
+type AppMetadata struct {
+	App      Metadata   `json:"app,omitempty"`
+	Fleets   []Metadata `json:"fleets,omitempty"`
+	Routes   []Metadata `json:"routes,omitempty"`
+	Products []Metadata `json:"products,omitempty"`
+}
+
+// Load metadata for the app
+func appGetMetadata(flagVerbose bool) (appMetadata AppMetadata, err error) {
+
+	rsp := map[string]interface{}{}
+	err = reqHubV0(flagVerbose, lib.ConfigAPIHub(), []byte("{\"req\":\"hub.app.get\"}"), "", "", "", "", false, false, nil, &rsp)
+	if err != nil {
+		return
+	}
+
+	// App info
+	appMetadata.App.UID = rsp["uid"].(string)
+	appMetadata.App.Name = rsp["label"].(string)
+	appMetadata.App.BA = rsp["billing_account_uid"].(string)
+
+	// Fleet info
+	settings, exists := rsp["info"].(map[string]interface{})
+	if exists {
+		fleets, exists := settings["fleet"].(map[string]interface{})
+		if exists {
+			items := []Metadata{}
+			for k, v := range fleets {
+				vj, ok := v.(map[string]interface{})
+				if ok {
+					i := Metadata{Name: vj["label"].(string), UID: k}
+					items = append(items, i)
+				}
+			}
+			appMetadata.Fleets = items
+		}
+	}
+
+	// Enum routes
+	rsp = map[string]interface{}{}
+	err = reqHubV0(flagVerbose, lib.ConfigAPIHub(), []byte("{\"req\":\"hub.app.test.route\"}"), "", "", "", "", false, false, nil, &rsp)
+	if err == nil {
+		body, exists := rsp["body"].(map[string]interface{})
+		if exists {
+			items := []Metadata{}
+			for k, v := range body {
+				vs, ok := v.(string)
+				if ok {
+					components := strings.Split(k, "/")
+					if len(components) > 1 {
+						i := Metadata{Name: vs, UID: components[1]}
+						items = append(items, i)
+					}
+				}
+			}
+			appMetadata.Routes = items
+		}
+	}
+
+	// Products
+	rsp = map[string]interface{}{}
+	err = reqHubV1(flagVerbose, lib.ConfigAPIHub(), "GET", "/v1/projects/"+appMetadata.App.UID+"/products", nil, &rsp)
+	if err == nil {
+		pi, exists := rsp["products"].([]interface{})
+		if exists {
+			items := []Metadata{}
+			for _, v := range pi {
+				p, ok := v.(map[string]interface{})
+				if ok {
+					i := Metadata{Name: p["label"].(string), UID: p["uid"].(string)}
+					items = append(items, i)
+				}
+				appMetadata.Products = items
+			}
+		}
+	}
+
+	// Done
+	return
+
+}
+
+// Get a device list given
+func appGetScope(scope string, flagVerbose bool) (appMetadata AppMetadata, scopeDevices []string, scopeFleets []string, err error) {
+
+	// Get the metadata before we begin, because at a minimum we need appUID
+	appMetadata, err = appGetMetadata(flagVerbose)
+	if err != nil {
+		return
+	}
+
+	// On the command line (but not inside files) we allow comma-separated lists
+	if strings.Contains(scope, ",") {
+		scopeList := strings.Split(scope, ",")
+		for _, scope := range scopeList {
+			err = addScope(scope, &appMetadata, &scopeDevices, &scopeFleets, flagVerbose)
+			if err != nil {
+				return
+			}
+		}
+	} else {
+		err = addScope(scope, &appMetadata, &scopeDevices, &scopeFleets, flagVerbose)
+		if err != nil {
+			return
+		}
+	}
+
+	// Remove duplicates
+	scopeDevices = sortAndRemoveDuplicates(scopeDevices)
+	scopeFleets = sortAndRemoveDuplicates(scopeFleets)
+
+	// Done
+	return
+
+}
+
+// Recursively add scope
+func addScope(scope string, appMetadata *AppMetadata, scopeDevices *[]string, scopeFleets *[]string, flagVerbose bool) (err error) {
+
+	if strings.HasPrefix(scope, "dev:") {
+		*scopeDevices = append(*scopeDevices, scope)
+		return
+	}
+
+	if strings.HasPrefix(scope, "imei:") {
+		// This is a pre-V1 legacy that still exists in some ancient fleets
+		*scopeDevices = append(*scopeDevices, scope)
+		return
+	}
+
+	if strings.HasPrefix(scope, "fleet:") {
+		*scopeFleets = append(*scopeFleets, scope)
+		return
+	}
+
+	// See if this is a fleet name, and translate it to an ID
+	if !strings.HasPrefix(scope, "@") {
+		for _, fleet := range (*appMetadata).Fleets {
+			if strings.EqualFold(scope, strings.TrimSpace(fleet.Name)) {
+				*scopeFleets = append(*scopeFleets, fleet.UID)
+				return
+			}
+		}
+		return fmt.Errorf("'%s' does not appear to be a device, fleet, @fleet indirection, or @file.ext indirection", scope)
+	}
+	indirectScope := strings.TrimPrefix(scope, "@")
+
+	// Process a fleet indirection.  First, find the fleet.
+	foundFleet := false
+	lookingFor := strings.TrimSpace(indirectScope)
+	for _, fleet := range (*appMetadata).Fleets {
+		if strings.EqualFold(lookingFor, strings.TrimSpace(fleet.UID)) || strings.EqualFold(lookingFor, strings.TrimSpace(fleet.Name)) {
+			foundFleet = true
+
+			pageSize := 100
+			pageNum := 0
+			for {
+				pageNum++
+
+				devices := notegoapi.GetDevicesResponse{}
+				url := fmt.Sprintf("/v1/projects/%s/fleets/%s/devices?pageSize=%d&pageNum=%d", appMetadata.App.UID, fleet.UID, pageSize, pageNum)
+				err = reqHubV1(flagVerbose, lib.ConfigAPIHub(), "GET", url, nil, &devices)
+				if err != nil {
+					return
+				}
+
+				for _, device := range devices.Devices {
+					err = addScope(device.UID, appMetadata, scopeDevices, scopeFleets, flagVerbose)
+					if err != nil {
+						return err
+					}
+				}
+
+				if !devices.HasMore {
+					break
+				}
+
+			}
+
+		}
+	}
+	if foundFleet {
+		return
+	}
+
+	// Process a file indirection
+	var contents []byte
+	contents, err = ioutil.ReadFile(indirectScope)
+	if err != nil {
+		return fmt.Errorf("%s: %s", indirectScope, err)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(contents))
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if trimmedLine := strings.TrimSpace(line); trimmedLine != "" {
+			err = addScope(trimmedLine, appMetadata, scopeDevices, scopeFleets, flagVerbose)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	err = scanner.Err()
+	return
+
+}
+
+// Sort and remove duplicates in a string slice
+func sortAndRemoveDuplicates(strings []string) []string {
+
+	sort.Strings(strings)
+
+	unique := make(map[string]struct{})
+	var result []string
+
+	for _, v := range strings {
+		if _, exists := unique[v]; !exists {
+			unique[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+
+	return result
+}

--- a/notehub/examples.txt
+++ b/notehub/examples.txt
@@ -1,77 +1,52 @@
-notehub '{"req":"hub.app.get"}'
 
-notehub '{"req":"hub.device.get"}'
+// General note-related
+notehub -product net.ozzie.ray:t -device dev:94deb82a98d0 '{"req":"note.update","file":"hub.db","note":"testnote","body":{"testfield":"testvalue"}}'
+notehub -product net.ozzie.ray:t -device dev:94deb82a98d0 '{"req":"note.get","file":"hub.db","note":"testnote"}'
 
-notehub '{"req":"hub.app.data.query",query:{"columns":".modified;.payload;.body","limit":25,"format":"json"}}'
+// Explore what notefiles exist on the notehub
+notehub -product net.ozzie.ray:t -device dev:94deb82a98d0 -explore
+notehub -product net.ozzie.ray:t -device dev:94deb82a98d0 -explore -reserved
 
-notehub -out test.csv '{"req":"hub.app.data.query",query:{"columns":".serial;device_uid:.device;.file;.note;body:q(.body::text);.payload","format":"csv"}}'
+// See what files have been uploaded to the app
+notehub -product net.ozzie.ray:t '{"req":"hub.app.upload.query"}'
 
-notehub '{"req":"hub.app.data.query",query:{"columns":".serial;.modified;.when;.where;.payload;.body","limit":25}}'
+// Upload a file to an app
+notehub -product net.ozzie.ray:t -upload test.bin
 
-notehub '{"req":"hub.app.data.query",query:{"columns":".modified;.body;.payload","limit":25,"where":".body.cpm::float < 30"}}'
+// Delete an uploaded file
+notehub -product net.ozzie.ray:t '{"req":"hub.app.upload.delete","name":"test-20181002225319.bin"}'
 
-notehub '{"req":"hub.app.data.query",query:{"columns":".modified;.payload;.body","limit":25,"where":".body.class::text <> '\''comms'\''"}}'
+// Get the metadata of an uploaded file
+notehub -product net.ozzie.ray:t '{"req":"hub.app.upload.get","name":"test-20181002225319.bin"}'
 
-notehub '{"req":"hub.app.data.query",query:{"columns":".modified;.body;.payload","limit":25,"where":".modified>=now()-interval '\''1 day'\''"}}'
+// Get the data from an uploaded file once you know the length from the metadata
+notehub -product net.ozzie.ray:t '{"req":"hub.app.upload.get","name":"test-20181002225319.bin","offset":0,"length":10}'
 
-notehub '{"req":"hub.app.data.query",query:{"columns":".body.severity;.modified,.body;.payload","limit":10,"where":".body.severity::int < 2"}}'
+// Set the metadata on an uploaded file
+notehub -product net.ozzie.ray:t '{"req":"hub.app.upload.set","name":"test-20181002225319.bin","body":{"testing":123},"contains":"Generate Python"}'
 
-notehub '{"req":"hub.app.data.query",query:{"count":true,"where":".body.severity::int < 2"}}'
+// Get the env vars for various scopes, returning a JSON object containing them
+notehub -product net.ozzie.ray:t -pretty -scope fleet:60379c1da2401609b8e1fb3eec2a186e -get-vars
+notehub -product net.ozzie.ray:t -pretty -scope dev:864475040518622 -get-vars
+notehub -product net.ozzie.ray:t -pretty -scope "Ray's Fleet" -get-vars
+notehub -product net.ozzie.ray:t -pretty -scope "@Ray's Fleet" -get-vars
 
-notehub '{"req":"hub.app.data.query",query:{"columns":"device_uid:.device;when_captured:q(.when::text);loc_olc:q(.where::text);.body.lnd_7318u;.body.lnd_7128ec;.body.env_temp;.body.env_humid;.body.env_press;.body.bat_voltage;.body.bat_current;.body.bat_charge;.body.opc_pm01_0;.body.opc_pm02_5;.body.opc_pm10_0","limit":100}}'
+// Get the env vars for a list of fleets stored in a file, returning a JSON object containing them
+fleets.txt
+	Ray's Fleet
+	fleet:60379c1da2401609b8e1fb3eec2a186e
+notehub -product net.ozzie.ray:t -pretty -scope @fleets.txt -get-vars
 
-notehub '{"req":"hub.app.data.query",query:{"columns":"device_uid:.device;when_captured:q(to_char(.when, '\''YYYY-MM-DD\"T\"HH24:MI:SSZ'\''));loc_olc:q(.where::text)","limit":100}}'
+// Get the env vars for a list of devices stored in a file, returning a JSON object containing them
+devices.txt
+	@Ray's Fleet
+	dev:864475040518622
+notehub -product net.ozzie.ray:t -pretty -scope @devices.txt -get-vars -pretty
 
-notehub '{"req":"hub.app.data.query",query:{"columns":".serial;.modified;.body","limit":25,"order":".serial"}}'
+// Set one env vars and remove one using a template directly on the command line
+notehub -product net.ozzie.ray:t -pretty -scope "@Ray's Fleet" -set-vars '{"var1":"val1","var2":"-"}'
 
-notehub '{"req":"note.add","file":"geiger.q","body":{"testfield":"testvalue"}}'
-
-notehub '{"req":"hub.app.data.query",query:{"columns":".modified;.when;.body;.payload","order":".modified","where":".body.test::text = '\''iccid:89011703278123166574:1522628156'\''"}}'
-
-notehub '{"req":"hub.app.data.query",query:{"columns":".modified;.where;.file;.payload;.body;.device","limit":5000,"order":".modified","descending":true,"format":"json"}}'
-
-notehub '{"req":"note.update","file":"hub.db","note":"testnote","body":{"testfield":"testvalue"}}'
-notehub '{"req":"note.get","file":"hub.db","note":"testnote"}'
-
-notehub -in testapp.json
-notehub -in testrpt.json
-notehub -in testweb1.json
-notehub -in testweb2.json
-notehub -in testmqtt.json
-notehub -in testm2x.json
+// Set env vars through a file-based template
+notehub -product net.ozzie.ray:t -pretty -scope "@Ray's Fleet" -set-vars @template
 
 
-notehub -upload test.bin
-
-notehub '{"req":"hub.app.upload.query"}'
-
-notehub '{"req":"hub.app.upload.delete","name":"test-20181002225319.bin"}'
-
-notehub '{"req":"hub.app.upload.get","name":"test-20181002225319.bin","offset":0,"length":10}'
-
-notehub '{"req":"hub.app.upload.set","name":"test-20181002225319.bin","body":{"testing":123},"contains":"Generate Python"}'
-
-notehub '{"req":"hub.app.upload.get","name":"test-20181002225319.bin"}'
-
-notehub '{"req":"hub.app.data.query",query:{"columns":".serial;.device;.modified;.when;.body;.payload","order":".modified","where":".device::text='\''imei:866425030050464'\'' or .device::text='\''imei:866425030050464:1543271941'\'' "}}'
-
-// To see what version of firmware is running on a notecard
-notehub  '{"req":"note.get","file":"_env.dbs","note":"device_vars"}'
-
-// For a DFU of Notecard
-notehub -upload ~/desktop/notecard.bin
-notehub -type firmware -upload ~/desktop/notecard.bin
-notehub -type firmware -upload ~/desktop/test.txt
-notehub -type notecard -upload ~/desktop/notecard.bin
-notehub -type notecard -upload ~/desktop/test.txt
-notehub '{"req":"hub.app.upload.query","type":"firmware"}'
-notehub '{"req":"hub.app.upload.query","type":"notecard"}'
-// Or for a DFU of an app
-notehub -upload ~/dev/tmp/arduino/airnote.ino.bin
-// ...then, optionaly, using the output from that command, substitute the "name" below and verify the contents build number, upload custom metadata, etc
-notehub '{"req":"hub.app.upload.set","name":"notecard-20181008172411.bin","body":{"your":"metadata"},"contains":"Blues Wireless Notecard"}'
-// ...or...
-notehub '{"req":"hub.app.upload.set","name":"airnote-20190407201549.ino.bin","body":{"your":"metadata"},"contains":"Airnote version"}'
-// ...then, modify the server's HubEnvVarCardFirmwareName (_fwc) with the "name" above.  That's it.
-// ...and if it fails for some reason, modify HubEnvVarCardFirmwareRetry (_fwc_retry) to bump it up by one, which will force a client retry
-// ...and all the while the device status should be being uploaded and viewable on the service.

--- a/notehub/explore.go
+++ b/notehub/explore.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Explore the contents of this device
-func explore(includeReserved bool, verbose bool) (err error) {
+func explore(includeReserved bool, verbose bool, pretty bool) (err error) {
 
 	// Get the list of notefiles
 	req := notehub.HubRequest{}
@@ -68,9 +68,15 @@ func explore(includeReserved bool, verbose bool) (err error) {
 			}
 			fmt.Printf("\n")
 			if n.Body != nil {
-				bodyJSON, err := note.JSONMarshal(*n.Body)
+				prefix := "            "
+				var bodyJSON []byte
+				if pretty {
+					bodyJSON, err = note.JSONMarshalIndent(*n.Body, prefix, "    ")
+				} else {
+					bodyJSON, err = note.JSONMarshal(*n.Body)
+				}
 				if err == nil {
-					fmt.Printf("            %s\n", string(bodyJSON))
+					fmt.Printf("%s%s\n", prefix, string(bodyJSON))
 				}
 			}
 			if n.Payload != nil {

--- a/notehub/vars.go
+++ b/notehub/vars.go
@@ -1,0 +1,131 @@
+// Copyright 2024 Blues Inc.  All rights reserved.
+// Use of this source code is governed by licenses granted by the
+// copyright holder including that found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/blues/note-cli/lib"
+	"github.com/blues/note-go/note"
+	notegoapi "github.com/blues/note-go/notehub/api"
+)
+
+type Vars map[string]string
+
+// Load env vars into metadata from a list of devices
+func varsGetFromDevices(appMetadata AppMetadata, uids []string, flagVerbose bool) (vars map[string]Vars, err error) {
+
+	vars = map[string]Vars{}
+
+	for _, deviceUID := range uids {
+		varsRsp := notegoapi.GetDeviceEnvironmentVariablesResponse{}
+		url := fmt.Sprintf("/v1/projects/%s/devices/%s/environment_variables", appMetadata.App.UID, deviceUID)
+		err = reqHubV1(flagVerbose, lib.ConfigAPIHub(), "GET", url, nil, &varsRsp)
+		if err != nil {
+			return
+		}
+		vars[deviceUID] = varsRsp.EnvironmentVariables
+	}
+
+	return
+
+}
+
+// Load env vars into metadata from a list of fleets
+func varsGetFromFleets(appMetadata AppMetadata, uids []string, flagVerbose bool) (vars map[string]Vars, err error) {
+
+	vars = map[string]Vars{}
+
+	for _, fleetUID := range uids {
+		varsRsp := notegoapi.GetFleetEnvironmentVariablesResponse{}
+		url := fmt.Sprintf("/v1/projects/%s/fleets/%s/environment_variables", appMetadata.App.UID, fleetUID)
+		err = reqHubV1(flagVerbose, lib.ConfigAPIHub(), "GET", url, nil, &varsRsp)
+		if err != nil {
+			return
+		}
+		vars[fleetUID] = varsRsp.EnvironmentVariables
+	}
+
+	return
+}
+
+// Load env vars into metadata from a list of devices and set their values
+func varsSetFromDevices(appMetadata AppMetadata, uids []string, template Vars, flagVerbose bool) (vars map[string]Vars, err error) {
+
+	vars = map[string]Vars{}
+
+	for _, deviceUID := range uids {
+
+		rspGet := notegoapi.GetDeviceEnvironmentVariablesResponse{}
+		url := fmt.Sprintf("/v1/projects/%s/devices/%s/environment_variables", appMetadata.App.UID, deviceUID)
+		err = reqHubV1(flagVerbose, lib.ConfigAPIHub(), "GET", url, nil, &rspGet)
+		if err != nil {
+			return
+		}
+
+		req := notegoapi.PutDeviceEnvironmentVariablesRequest{}
+		req.EnvironmentVariables = rspGet.EnvironmentVariables
+		for k, v := range template {
+			req.EnvironmentVariables[k] = v
+		}
+
+		var reqJSON []byte
+		reqJSON, err = note.JSONMarshal(req)
+		if err != nil {
+			return
+		}
+
+		rspPut := notegoapi.PutDeviceEnvironmentVariablesResponse{}
+		err = reqHubV1(flagVerbose, lib.ConfigAPIHub(), "PUT", url, reqJSON, &rspPut)
+		if err != nil {
+			return
+		}
+
+		vars[deviceUID] = rspPut.EnvironmentVariables
+
+	}
+
+	return
+
+}
+
+// Load env vars into metadata from a list of fleets and set their values
+func varsSetFromFleets(appMetadata AppMetadata, uids []string, template Vars, flagVerbose bool) (vars map[string]Vars, err error) {
+
+	vars = map[string]Vars{}
+
+	for _, fleetUID := range uids {
+
+		rspGet := notegoapi.GetFleetEnvironmentVariablesResponse{}
+		url := fmt.Sprintf("/v1/projects/%s/fleets/%s/environment_variables", appMetadata.App.UID, fleetUID)
+		err = reqHubV1(flagVerbose, lib.ConfigAPIHub(), "GET", url, nil, &rspGet)
+		if err != nil {
+			return
+		}
+
+		req := notegoapi.PutFleetEnvironmentVariablesRequest{}
+		req.EnvironmentVariables = rspGet.EnvironmentVariables
+		for k, v := range template {
+			req.EnvironmentVariables[k] = v
+		}
+
+		var reqJSON []byte
+		reqJSON, err = note.JSONMarshal(req)
+		if err != nil {
+			return
+		}
+
+		rspPut := notegoapi.PutFleetEnvironmentVariablesResponse{}
+		err = reqHubV1(flagVerbose, lib.ConfigAPIHub(), "PUT", url, reqJSON, &rspPut)
+		if err != nil {
+			return
+		}
+
+		vars[fleetUID] = rspPut.EnvironmentVariables
+
+	}
+
+	return
+}


### PR DESCRIPTION
I also added a -pretty so that the json objects output by these commands can be visually pleasing.

// Get the env vars for various scopes, returning a JSON object containing them notehub -product net.ozzie.ray:t -pretty -scope fleet:60379c1da2401609b8e1fb3eec2a186e -get-vars notehub -product net.ozzie.ray:t -pretty -scope dev:864475040518622 -get-vars notehub -product net.ozzie.ray:t -pretty -scope "Ray's Fleet" -get-vars notehub -product net.ozzie.ray:t -pretty -scope "@Ray's Fleet" -get-vars

// Get the env vars for a list of fleets stored in a file, returning a JSON object containing them fleets.txt
	Ray's Fleet
	fleet:60379c1da2401609b8e1fb3eec2a186e
notehub -product net.ozzie.ray:t -pretty -scope @fleets.txt -get-vars

// Get the env vars for a list of devices stored in a file, returning a JSON object containing them devices.txt
	@Ray's Fleet
	dev:864475040518622
notehub -product net.ozzie.ray:t -pretty -scope @devices.txt -get-vars -pretty

// Set one env vars and remove one using a template directly on the command line notehub -product net.ozzie.ray:t -pretty -scope "@Ray's Fleet" -set-vars '{"var1":"val1","var2":"-"}'

// Set env vars through a file-based template
notehub -product net.ozzie.ray:t -pretty -scope "@Ray's Fleet" -set-vars @template