### PR TITLE
NF-782: Close Notecard before exiting main.

### DIFF
--- a/notecard/main.go
+++ b/notecard/main.go
@@ -730,6 +730,8 @@ func main() {
 		os.Exit(exitFail)
 	}
 
+	card.Close()
+
 	// Success
 	os.Exit(exitOk)
 


### PR DESCRIPTION
I was seeing issues with the Notecard CLI where the card's USB port was clearly not in use, but I was still getting this error:

{"err":"error opening serial port /tmp/card_usb at 115200: no such file or directory {io}"}

This was always after I had run one CLI command first, so it seemed like something was not being cleaned up. Indeed, in main() there was no call to the Close() function. This commit adds that, and now I don't see the problem anymore.