### PR TITLE
NF-782: Close Notecard before exiting REPL (i.e. one obtained with -play)

### DIFF
--- a/notecard/main.go
+++ b/notecard/main.go
@@ -730,6 +730,8 @@ func main() {
 		os.Exit(exitFail)
 	}
 
+	// If we don't do this, the Notecard port that was being used may
+	// appear as "busy" even though it's no longer in use.
 	card.Close()
 
 	// Success

--- a/notecard/repl.go
+++ b/notecard/repl.go
@@ -198,9 +198,14 @@ repl:
 			break
 		} else {
 			fmt.Printf("error reading line: %s\n", err)
+			repl.context.Close()
 			return 1
 		}
 	}
+
+	// If we don't do this, the Notecard port that was being used may
+	// appear as "busy" even though it's no longer in use.
+	repl.context.Close()
 
 	return 0
 }


### PR DESCRIPTION
I solved this for one-off requests with [this other PR](https://github.com/blues/note-cli/pull/26). This one solves the same problem for a `-play` REPL.