### PR TITLE
Make sure to close Notecard connection whenever CLI exits.

### DIFF
--- a/notecard/repl.go
+++ b/notecard/repl.go
@@ -86,6 +86,7 @@ func (repl *REPL) writeHistory() {
 func (repl *REPL) close() {
 	repl.writeHistory()
 	repl.liner.Close()
+	repl.context.Close()
 }
 
 // Start the read/eval/print loop which will accept user input
@@ -198,14 +199,9 @@ repl:
 			break
 		} else {
 			fmt.Printf("error reading line: %s\n", err)
-			repl.context.Close()
 			return 1
 		}
 	}
-
-	// If we don't do this, the Notecard port that was being used may
-	// appear as "busy" even though it's no longer in use.
-	repl.context.Close()
 
 	return 0
 }


### PR DESCRIPTION
I fixed this for `-play`, but I noticed it wasn't fixed for `-trace`. I also noticed that it wasn't closing the connection properly on signals (e.g. SIGTERM). I reworked the code a bit so that now we make sure to call close when a signal terminates the CLI AND in other, non-signal-triggered exit scenarios by using `defer`.