### PR TITLE
Notecard CLI: Return from main rather than doing os.Exit(0).

### DIFF
--- a/notecard/main.go
+++ b/notecard/main.go
@@ -22,7 +22,6 @@ import (
 )
 
 // Exit codes
-const exitOk = 0
 const exitFail = 1
 
 // The open notecard
@@ -746,10 +745,6 @@ func main() {
 		}
 		os.Exit(exitFail)
 	}
-
-	// Success
-	os.Exit(exitOk)
-
 }
 
 func accumulateInfoErr(infoErr error, newErr error) error {


### PR DESCRIPTION
This ensures the deferred cleanup function that closes the Notecard gets called. Doing os.Exit(0) will not call deferred functions. The problem is that if you do this:

```
notecard -port /tmp/ns_card_usb -req '{"req":"card.version"}'
```

And run it again after that, the second time will say the port is still busy, because it was never properly closed.