### PR TITLE
fix: nil error SEGFAULT

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "inputs": [
+        {
+            "id": "requestJson",
+            "type": "promptString",
+            "description": "Enter the JSON request string for the CLI",
+            "default": "{\"req\":\"card.attn\",\"mode\":\"watchdog\",\"seconds\":30}"
+        }
+    ],
+    "configurations": [
+        {
+            "name": "Launch Notecard CLI",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/notecard",
+            "args": ["-req", "${input:requestJson}"],
+            "env": {
+                "BLUES": "abucknall@blues.com"
+            }
+        },
+        {
+            "name": "Launch Notehub CLI",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/notehub",
+            "args": ["-req", "${input:requestJson}"]
+        }
+    ]
+}

--- a/notecard/validate.go
+++ b/notecard/validate.go
@@ -81,6 +81,12 @@ func fetchAndCacheSchema(url string, verbose bool) (io.Reader, error) {
 }
 
 func formatErrorMessage(reqType string, errUnformatted error) (err error) {
+	// Check if the error is nil
+	if errUnformatted == nil {
+		return nil
+	}
+
+	// Convert the error to a string
 	errMsg := errUnformatted.Error()
 
 	// Define constants
@@ -227,18 +233,24 @@ func resolveSchemaError(reqMap map[string]interface{}, verbose bool) (err error)
 	reqTypeStr, ok := reqType.(string)
 	if !ok {
 		err = fmt.Errorf("request type not a string")
-	} else if reqTypeStr == "" {
-		err = fmt.Errorf("no request type specified")
-	} else {
+		return
+	}
+
+	// Validate against the specific request schema
+	schemaPath := filepath.Join(cacheDir, reqTypeStr+".req.notecard.api.json")
+	if _, err = os.Stat(schemaPath); os.IsNotExist(err) {
+		err = fmt.Errorf("unknown request type: %s", reqTypeStr)
+	} else if err == nil {
 		var reqSchema *jsonschema.Schema
-		reqSchema, err = jsonschema.Compile(filepath.Join(cacheDir, reqTypeStr+".req.notecard.api.json"))
+		reqSchema, err = jsonschema.Compile(schemaPath)
 		if err == nil {
 			err = reqSchema.Validate(reqMap)
-			if !verbose {
+			if err != nil && !verbose {
 				err = formatErrorMessage(reqTypeStr, err)
 			}
 		}
 	}
+
 	return err
 }
 

--- a/notecard/validate.go
+++ b/notecard/validate.go
@@ -233,20 +233,24 @@ func resolveSchemaError(reqMap map[string]interface{}, verbose bool) (err error)
 	reqTypeStr, ok := reqType.(string)
 	if !ok {
 		err = fmt.Errorf("request type not a string")
-		return
-	}
+	} else if reqTypeStr == "" {
+		err = fmt.Errorf("no request type specified")
+	} else {
+		// Normalize request type
+		reqTypeStr = strings.ToLower(reqTypeStr)
 
-	// Validate against the specific request schema
-	schemaPath := filepath.Join(cacheDir, reqTypeStr+".req.notecard.api.json")
-	if _, err = os.Stat(schemaPath); os.IsNotExist(err) {
-		err = fmt.Errorf("unknown request type: %s", reqTypeStr)
-	} else if err == nil {
-		var reqSchema *jsonschema.Schema
-		reqSchema, err = jsonschema.Compile(schemaPath)
-		if err == nil {
-			err = reqSchema.Validate(reqMap)
-			if err != nil && !verbose {
-				err = formatErrorMessage(reqTypeStr, err)
+		// Validate against the specific request schema
+		schemaPath := filepath.Join(cacheDir, reqTypeStr+".req.notecard.api.json")
+		if _, err = os.Stat(schemaPath); os.IsNotExist(err) {
+			err = fmt.Errorf("unknown request type: %s", reqTypeStr)
+		} else if err == nil {
+			var reqSchema *jsonschema.Schema
+			reqSchema, err = jsonschema.Compile(schemaPath)
+			if err == nil {
+				err = reqSchema.Validate(reqMap)
+				if err != nil && !verbose {
+					err = formatErrorMessage(reqTypeStr, err)
+				}
 			}
 		}
 	}

--- a/notecard/validate.go
+++ b/notecard/validate.go
@@ -236,9 +236,6 @@ func resolveSchemaError(reqMap map[string]interface{}, verbose bool) (err error)
 	} else if reqTypeStr == "" {
 		err = fmt.Errorf("no request type specified")
 	} else {
-		// Normalize request type
-		reqTypeStr = strings.ToLower(reqTypeStr)
-
 		// Validate against the specific request schema
 		schemaPath := filepath.Join(cacheDir, reqTypeStr+".req.notecard.api.json")
 		if _, err = os.Stat(schemaPath); os.IsNotExist(err) {


### PR DESCRIPTION
- Performs `nil` check on error before dereference
- Lowercases request type value in schema file path
- Provides `launch.json` for debugging `notecard` and `notehub` CLIs
- Improves error message readability for unknown request.
