### PR TITLE
Fix: Remove the signout from authSigninToken

### DIFF
--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -22,12 +22,6 @@ import (
 // Sign into the notehub account with a token
 func authSignInToken(token string) (err error) {
 
-	// Sign out
-	_, _, authenticated := lib.ConfigSignedIn()
-	if authenticated {
-		authSignOut()
-	}
-
 	// Print hub if not the default
 	if lib.Config.Hub != "" {
 		fmt.Printf("notehub %s\n", lib.Config.Hub)


### PR DESCRIPTION
Fix: Remove the signout from authSigninToken as it was hitting the signout endpoint that invalidates the token.

I believe this is needed because the cloud team recently added code to invalidate tokens when signing out, so hitting this endpoint as part of authSigninToken was causing us to invalidate the very token we were trying to use.