### PR TITLE
feat: add -projects flag to list Notehub projects

### DIFF
--- a/notehub/app.go
+++ b/notehub/app.go
@@ -301,8 +301,15 @@ func addScope(scope string, appMetadata *AppMetadata, scopeDevices *[]string, sc
 
 }
 
+// ProjectInfo represents a project with its products
+type ProjectInfo struct {
+	Name     string     `json:"name,omitempty"`
+	UID      string     `json:"uid,omitempty"`
+	Products []Metadata `json:"products,omitempty"`
+}
+
 // List all projects accessible to the authenticated user
-func appListProjects(flagVerbose bool) (projects []Metadata, err error) {
+func appListProjects(flagVerbose bool) (projects []ProjectInfo, err error) {
 	rsp, err := reqHubV1JSON(flagVerbose, lib.ConfigAPIHub(), "GET", "/v1/projects", nil)
 	if err != nil {
 		return
@@ -315,11 +322,33 @@ func appListProjects(flagVerbose bool) (projects []Metadata, err error) {
 	items, _ := parsed["projects"].([]interface{})
 	for _, v := range items {
 		p, ok := v.(map[string]interface{})
-		if ok {
-			uid, _ := p["uid"].(string)
-			label, _ := p["label"].(string)
-			projects = append(projects, Metadata{Name: label, UID: uid})
+		if !ok {
+			continue
 		}
+		uid, _ := p["uid"].(string)
+		label, _ := p["label"].(string)
+		info := ProjectInfo{Name: label, UID: uid}
+
+		// Fetch products for this project
+		productsRsp := map[string]interface{}{}
+		err = reqHubV1(flagVerbose, lib.ConfigAPIHub(), "GET", "/v1/projects/"+uid+"/products", nil, &productsRsp)
+		if err == nil {
+			pi, exists := productsRsp["products"].([]interface{})
+			if exists {
+				for _, pv := range pi {
+					pp, ok := pv.(map[string]interface{})
+					if ok {
+						info.Products = append(info.Products, Metadata{
+							Name: pp["label"].(string),
+							UID:  pp["uid"].(string),
+						})
+					}
+				}
+			}
+		}
+		err = nil // don't fail the whole listing if one project's products can't be fetched
+
+		projects = append(projects, info)
 	}
 	return
 }

--- a/notehub/app.go
+++ b/notehub/app.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/blues/note-cli/lib"
+	"github.com/blues/note-go/note"
 	notegoapi "github.com/blues/note-go/notehub/api"
 )
 
@@ -298,6 +299,29 @@ func addScope(scope string, appMetadata *AppMetadata, scopeDevices *[]string, sc
 	err = scanner.Err()
 	return
 
+}
+
+// List all projects accessible to the authenticated user
+func appListProjects(flagVerbose bool) (projects []Metadata, err error) {
+	rsp, err := reqHubV1JSON(flagVerbose, lib.ConfigAPIHub(), "GET", "/v1/projects", nil)
+	if err != nil {
+		return
+	}
+	var parsed map[string]interface{}
+	err = note.JSONUnmarshal(rsp, &parsed)
+	if err != nil {
+		return
+	}
+	items, _ := parsed["projects"].([]interface{})
+	for _, v := range items {
+		p, ok := v.(map[string]interface{})
+		if ok {
+			uid, _ := p["uid"].(string)
+			label, _ := p["label"].(string)
+			projects = append(projects, Metadata{Name: label, UID: uid})
+		}
+	}
+	return
 }
 
 // Sort and remove duplicates in a string slice

--- a/notehub/main.go
+++ b/notehub/main.go
@@ -43,6 +43,7 @@ func getFlagGroups() []lib.FlagGroup {
 			Name:        "scope",
 			Description: "Project & Device Scope",
 			Flags: []*flag.Flag{
+				lib.GetFlagByName("projects"),
 				lib.GetFlagByName("project"),
 				lib.GetFlagByName("provision"),
 				lib.GetFlagByName("product"),
@@ -168,6 +169,8 @@ func main() {
 	flag.StringVar(&flagSn, "sn", "", "serial number")
 	var flagProvision bool
 	flag.BoolVar(&flagProvision, "provision", false, "provision devices")
+	var flagProjects bool
+	flag.BoolVar(&flagProjects, "projects", false, "list all projects")
 
 	// Parse these flags and also the note tool config flags
 	err := lib.FlagParse(false, true)
@@ -269,6 +272,27 @@ func main() {
 	if err == nil && flagVersion {
 		didSomething = true
 		fmt.Printf("Notehub CLI Version: %s\n", version)
+	}
+
+	if err == nil && flagProjects {
+		didSomething = true
+		err = withCreds(credentials, func() (err error) {
+			projects, err := appListProjects(flagVerbose)
+			if err != nil {
+				return err
+			}
+			var projectsJSON []byte
+			if flagPretty {
+				projectsJSON, err = note.JSONMarshalIndent(projects, "", "    ")
+			} else {
+				projectsJSON, err = note.JSONMarshal(projects)
+			}
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s\n", projectsJSON)
+			return nil
+		})
 	}
 
 	if flagReq != "" || flagUpload != "" {


### PR DESCRIPTION
## Summary
- Adds a new `-projects` flag to the notehub CLI that lists all Notehub projects accessible to the authenticated user
- Each project includes its name, UID, and associated product UIDs
- Supports `-pretty` for formatted JSON output and `-verbose` for request/response debugging

## Test plan
- [ ] Run `notehub -projects` and verify JSON output with project names, UIDs, and products
- [ ] Run `notehub -projects -pretty` and verify pretty-printed output
- [ ] Run `notehub -projects -verbose` and verify API requests are shown
- [ ] Run without authentication and verify appropriate error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)